### PR TITLE
Dockerfile (ubuntu18.04): include iptables

### DIFF
--- a/ci-scripts/Dockerfile.ubuntu18.04
+++ b/ci-scripts/Dockerfile.ubuntu18.04
@@ -75,6 +75,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get upgrade --yes && DE
     psmisc \
     net-tools \
     iproute2 \
+    iptables \
     tshark \
     libgoogle-glog0v5 \
     libdouble-conversion1 \


### PR DESCRIPTION
The SPGW-U calls `iptables` during startup, but it is never installed in the Dockerfile for ubuntu 18.04. As far as I can tell, this fixes issues where UE-originating traffic makes it to the SPGW-U, but the response never reaches the UE: https://github.com/OPENAIRINTERFACE/openair-epc-fed/issues/3

Seems to be called from this line: https://github.com/OPENAIRINTERFACE/openair-spgwu-tiny/blob/5ca383967fb80910ce92a596ad2853dd5aa520bb/src/spgwu/simpleswitch/pfcp_switch.cpp#L271

I'm following this guide: 
https://github.com/OPENAIRINTERFACE/openair-epc-fed/blob/master/docs/DEPLOY_HOME.md

My log:
```
[2020-10-07T14:57:57.952324] [spgwu] [spgwu_s1u] [start] Started
sh: 1: iptables: not found
net.ipv4.conf.all.forwarding = 1
```
