### PR TITLE
[CI]: initial RHEL8 native framework

### DIFF
--- a/build/scripts/build_helper
+++ b/build/scripts/build_helper
@@ -38,7 +38,7 @@ case "$OS_DISTRO" in
   ubuntu) OS_BASEDISTRO="debian"; INSTALLER="apt-get"; CMAKE="cmake" ;;
 esac
 
-IS_CONTAINER=`egrep -c "docker|podman|kubepods" /proc/self/cgroup || true`
+IS_CONTAINER=`egrep -c "docker|podman|kubepods|libpod|runc-buildah" /proc/self/cgroup || true`
 
 if [ $IS_CONTAINER -eq 0 ]
 then

--- a/ci-scripts/Jenkinsfile-GitHub-Docker
+++ b/ci-scripts/Jenkinsfile-GitHub-Docker
@@ -37,10 +37,16 @@ def cn_ci_host = params.Host_CN_CI_Server
 // for lock
 def cn_ci_resource = params.DockerContainers
 
-// Location of the 2nd CN executor
-def new_host_flag = false
-def new_host = ""
-def new_host_user = ""
+// Location of the Remote Ubuntu18 CN executor
+def rem_u18_host_flag = false
+def rem_u18_host = ""
+def rem_u18_host_user = ""
+
+// Location of the Remote RHEL CN executor
+def rem_rhel_host_flag = false
+def rem_rhel_host = ""
+def rem_rhel_host_user = ""
+def rem_rhel8_resource = params.PodmanContainers
 
 // Variables to pass to the FED Test job
 def spgwu_tag = 'develop'
@@ -69,17 +75,25 @@ pipeline {
           JOB_TIMESTAMP = JOB_TIMESTAMP.trim()
 
           if (params.Host_CN_CI_2nd_Server_Flag != null) {
-            new_host_flag = params.Host_CN_CI_2nd_Server_Flag
-            if (new_host_flag) {
-              new_host = params.Host_CN_CI_2nd_Server
-              new_host_user = params.Host_CN_CI_2nd_Server_Login
+            rem_u18_host_flag = params.Host_CN_CI_2nd_Server_Flag
+            if (rem_u18_host_flag) {
+              rem_u18_host = params.Host_CN_CI_2nd_Server
+              rem_u18_host_user = params.Host_CN_CI_2nd_Server_Login
               echo "1st Node   is ${NODE_NAME}"
-              echo "2nd Node   is ${new_host}"
+              echo "2nd Node   is ${rem_u18_host}"
             } else {
-              echo "Node       is ${NODE_NAME}"
+              echo "U18 Node   is ${NODE_NAME}"
             }
           } else {
             echo "Node       is ${NODE_NAME}"
+          }
+          if (params.Remote_RHEL_Server_Flag != null) {
+            rem_rhel_host_flag = params.Remote_RHEL_Server_Flag
+            if (rem_rhel_host_flag) {
+              rem_rhel_host = params.Remote_RHEL_Server_Name
+              rem_rhel_host_user = params.Remote_RHEL_Server_Login
+              echo "RHEL Node  is ${rem_rhel_host}"
+            }
           }
           echo "Git URL    is ${GIT_URL}"
 
@@ -110,33 +124,31 @@ pipeline {
           sh "git clean -x -d -f > /dev/null 2>&1"
           sh "tar -cjhf /tmp/openair-spgwu.tar.bz2 ."
           sh "mv /tmp/openair-spgwu.tar.bz2 ."
-          copyTo2ndServer('openair-spgwu.tar.bz2', new_host_flag, new_host_user, new_host)
-          sh "mkdir -p archives"
-          if (new_host_flag) {
-            sh "mkdir -p archives/oai-spgwu-cfg"
-          }
+          copyTo2ndServer('openair-spgwu.tar.bz2', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
+          copyTo2ndServer('openair-spgwu.tar.bz2', rem_rhel_host_flag, rem_rhel_host_user, rem_rhel_host)
+          sh "mkdir -p archives/oai-spgwu-cfg"
         }
       }
     }
     stage('Build Core Network Function') {
       parallel {
-        stage ('Build SPGW-U Image') {
+        stage ('Build U18 SPGW-U Image') {
           steps {
             script {
               if (env.ghprbPullId == null) {
                 // Currently this pipeline only runs for pushes to `develop` branch
                 // First clean image registry
-                myShCmd('docker image rm oai-spgwu-tiny:develop', new_host_flag, new_host_user, new_host)
+                myShCmd('docker image rm oai-spgwu-tiny:develop', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
               }
-              myShCmd('docker image prune --force', new_host_flag, new_host_user, new_host)
-              myShCmd('docker build --target oai-spgwu-tiny --tag oai-spgwu-tiny:' + spgwu_tag + ' --file docker/Dockerfile.ubuntu18.04 --build-arg EURECOM_PROXY="http://proxy.eurecom.fr:8080" . > archives/spgwu_docker_image_build.log 2>&1', new_host_flag, new_host_user, new_host)
-              myShCmd('docker image ls >> archives/spgwu_docker_image_build.log', new_host_flag, new_host_user, new_host)
+              myShCmd('docker image prune --force', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
+              myShCmd('docker build --target oai-spgwu-tiny --tag oai-spgwu-tiny:' + spgwu_tag + ' --file docker/Dockerfile.ubuntu18.04 --build-arg EURECOM_PROXY="http://proxy.eurecom.fr:8080" . > archives/spgwu_docker_image_build.log 2>&1', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
+              myShCmd('docker image ls >> archives/spgwu_docker_image_build.log', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
             }
           }
           post {
             always {
               script {
-                copyFrom2ndServer('archives/spgwu_docker_image_build.log', 'archives', new_host_flag, new_host_user, new_host)
+                copyFrom2ndServer('archives/spgwu_docker_image_build.log', 'archives', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
               }
             }
             success {
@@ -147,30 +159,67 @@ pipeline {
             }
           }
         }
-        // Running CPPCHECK in parallel to gain time
-        stage ('Static Code Analysis') {
+        stage ('Build RHEL8 SPGW-U Image') {
+          when { expression {rem_rhel_host_flag} }
           steps {
-            script {
-              // Running on xenial to have 1.72 version of cppcheck
-              myShCmd('docker run --name ci-cn-cppcheck -d ubuntu:xenial /bin/bash -c "sleep infinity"', new_host_flag, new_host_user, new_host)
-              myShCmd('docker exec ci-cn-cppcheck /bin/bash -c "apt-get update && apt-get upgrade --yes" > archives/cppcheck_install.log', new_host_flag, new_host_user, new_host)
-              myShCmd('docker exec ci-cn-cppcheck /bin/bash -c "apt-get install --yes cppcheck bzip2" >> archives/cppcheck_install.log', new_host_flag, new_host_user, new_host)
-
-              myShCmd('docker cp ./openair-spgwu.tar.bz2 ci-cn-cppcheck:/home', new_host_flag, new_host_user, new_host)
-              myShCmd('docker exec ci-cn-cppcheck /bin/bash -c "cd /home && tar -xjf openair-spgwu.tar.bz2"', new_host_flag, new_host_user, new_host)
-              myShCmd('docker exec ci-cn-cppcheck /bin/bash -c "rm -f /home/openair-spgwu.tar.bz2"', new_host_flag, new_host_user, new_host)
-
-              myShCmd('docker exec ci-cn-cppcheck /bin/bash -c "cd /home && cppcheck --enable=warning --force --xml --xml-version=2 src 2> cppcheck.xml 1> cppcheck_build.log"', new_host_flag, new_host_user, new_host)
+            lock (rem_rhel8_resource) {
+              script {
+                if (env.ghprbPullId == null) {
+                  // Currently this pipeline only runs for pushes to `develop` branch
+                  // First clean image registry
+                  myShCmd('sudo podman image rm oai-spgwu-tiny:develop || true', rem_rhel_host_flag, rem_rhel_host_user, rem_rhel_host)
+                } else {
+                  // In case we forgot during a previous run
+                  myShCmd('sudo podman image rm oai-spgwu-tiny:' + spgwu_tag + ' || true', rem_rhel_host_flag, rem_rhel_host_user, rem_rhel_host)
+                }
+                myShCmd('sudo podman image prune --force', rem_rhel_host_flag, rem_rhel_host_user, rem_rhel_host)
+                // Copy the RHEL Host certificates for building
+                myShCmd('mkdir -p tmp/ca tmp/entitlement', rem_rhel_host_flag, rem_rhel_host_user, rem_rhel_host)
+                myShCmd('cp /etc/pki/entitlement/*pem tmp/entitlement', rem_rhel_host_flag, rem_rhel_host_user, rem_rhel_host)
+                myShCmd('sudo cp /etc/rhsm/ca/redhat-uep.pem tmp/ca', rem_rhel_host_flag, rem_rhel_host_user, rem_rhel_host)
+                myShCmd('sudo podman build --target oai-spgwu-tiny --tag oai-spgwu-tiny:' + spgwu_tag + ' --file docker/Dockerfile.rhel8  --build-arg EURECOM_PROXY="http://proxy.eurecom.fr:8080" . > archives/spgwu_podman_image_build.log 2>&1', rem_rhel_host_flag, rem_rhel_host_user, rem_rhel_host)
+                myShCmd('sudo podman image ls >> archives/spgwu_podman_image_build.log', rem_rhel_host_flag, rem_rhel_host_user, rem_rhel_host)
+              }
             }
           }
           post {
             always {
               script {
-                myShCmd('docker cp ci-cn-cppcheck:/home/cppcheck.xml archives', new_host_flag, new_host_user, new_host)
-                myShCmd('docker cp ci-cn-cppcheck:/home/cppcheck_build.log archives', new_host_flag, new_host_user, new_host)
-                copyFrom2ndServer('archives/cppcheck*.*', 'archives', new_host_flag, new_host_user, new_host)
+                copyFrom2ndServer('archives/spgwu_podman_image_build.log', 'archives', rem_rhel_host_flag, rem_rhel_host_user, rem_rhel_host)
+              }
+            }
+            success {
+              sh "echo 'OAI-SPGW-U PODMAN RHEL8 IMAGE BUILD: OK' >> archives/spgwu_podman_image_build.log"
+            }
+            unsuccessful {
+              sh "echo 'OAI-SPGW-U PODMAN RHEL8 IMAGE BUILD: KO' >> archives/spgwu_podman_image_build.log"
+            }
+          }
+        }
+        // Running CPPCHECK in parallel to gain time
+        stage ('Static Code Analysis') {
+          steps {
+            script {
+              // Running on xenial to have 1.72 version of cppcheck
+              myShCmd('docker run --name ci-cn-cppcheck -d ubuntu:xenial /bin/bash -c "sleep infinity"', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
+              myShCmd('docker exec ci-cn-cppcheck /bin/bash -c "apt-get update && apt-get upgrade --yes" > archives/cppcheck_install.log', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
+              myShCmd('docker exec ci-cn-cppcheck /bin/bash -c "apt-get install --yes cppcheck bzip2" >> archives/cppcheck_install.log', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
+
+              myShCmd('docker cp ./openair-spgwu.tar.bz2 ci-cn-cppcheck:/home', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
+              myShCmd('docker exec ci-cn-cppcheck /bin/bash -c "cd /home && tar -xjf openair-spgwu.tar.bz2"', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
+              myShCmd('docker exec ci-cn-cppcheck /bin/bash -c "rm -f /home/openair-spgwu.tar.bz2"', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
+
+              myShCmd('docker exec ci-cn-cppcheck /bin/bash -c "cd /home && cppcheck --enable=warning --force --xml --xml-version=2 src 2> cppcheck.xml 1> cppcheck_build.log"', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
+            }
+          }
+          post {
+            always {
+              script {
+                myShCmd('docker cp ci-cn-cppcheck:/home/cppcheck.xml archives', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
+                myShCmd('docker cp ci-cn-cppcheck:/home/cppcheck_build.log archives', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
+                copyFrom2ndServer('archives/cppcheck*.*', 'archives', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
                 // no need to keep the cppcheck container
-                myShCmd('docker rm -f ci-cn-cppcheck', new_host_flag, new_host_user, new_host)
+                myShCmd('docker rm -f ci-cn-cppcheck', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
               }
             }
             success {
@@ -185,37 +234,37 @@ pipeline {
         stage ('Code Formatting Checker') {
           steps {
             script {
-              myShCmd('docker run --name ci-cn-clang-formatter -d ubuntu:bionic /bin/bash -c "sleep infinity"', new_host_flag, new_host_user, new_host)
-              myShCmd('docker exec ci-cn-clang-formatter /bin/bash -c "apt-get update && apt-get upgrade --yes" > archives/clang_format_install.log', new_host_flag, new_host_user, new_host)
-              myShCmd('docker exec ci-cn-clang-formatter /bin/bash -c "apt-get install --yes git tree bzip2" >> archives/clang_format_install.log', new_host_flag, new_host_user, new_host)
+              myShCmd('docker run --name ci-cn-clang-formatter -d ubuntu:bionic /bin/bash -c "sleep infinity"', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
+              myShCmd('docker exec ci-cn-clang-formatter /bin/bash -c "apt-get update && apt-get upgrade --yes" > archives/clang_format_install.log', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
+              myShCmd('docker exec ci-cn-clang-formatter /bin/bash -c "apt-get install --yes git tree bzip2" >> archives/clang_format_install.log', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
 
-              myShCmd('docker cp ./openair-spgwu.tar.bz2 ci-cn-clang-formatter:/home', new_host_flag, new_host_user, new_host)
-              myShCmd('docker exec ci-cn-clang-formatter /bin/bash -c "cd /home && tar -xjf openair-spgwu.tar.bz2"', new_host_flag, new_host_user, new_host)
-              myShCmd('docker exec ci-cn-clang-formatter /bin/bash -c "rm -f /home/openair-spgwu.tar.bz2"', new_host_flag, new_host_user, new_host)
+              myShCmd('docker cp ./openair-spgwu.tar.bz2 ci-cn-clang-formatter:/home', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
+              myShCmd('docker exec ci-cn-clang-formatter /bin/bash -c "cd /home && tar -xjf openair-spgwu.tar.bz2"', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
+              myShCmd('docker exec ci-cn-clang-formatter /bin/bash -c "rm -f /home/openair-spgwu.tar.bz2"', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
 
               // We install a dedicated version (installed on our CI server).
-              myShCmd('docker cp /opt/clang-format/9.0.0/bin/clang-format ci-cn-clang-formatter:/usr/local/bin', new_host_flag, new_host_user, new_host)
+              myShCmd('docker cp /opt/clang-format/9.0.0/bin/clang-format ci-cn-clang-formatter:/usr/local/bin', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
               if (env.ghprbPullId != null) {
-                myShCmd('docker exec ci-cn-clang-formatter /bin/bash -c "cd /home && ./ci-scripts/checkCodingFormattingRules.sh --src-branch ' + env.ghprbSourceBranch +' --target-branch ' + env.ghprbTargetBranch + '"', new_host_flag, new_host_user, new_host)
+                myShCmd('docker exec ci-cn-clang-formatter /bin/bash -c "cd /home && ./ci-scripts/checkCodingFormattingRules.sh --src-branch ' + env.ghprbSourceBranch +' --target-branch ' + env.ghprbTargetBranch + '"', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
               } else {
-                myShCmd('docker exec ci-cn-clang-formatter /bin/bash -c "cd /home && ./ci-scripts/checkCodingFormattingRules.sh"', new_host_flag, new_host_user, new_host)
+                myShCmd('docker exec ci-cn-clang-formatter /bin/bash -c "cd /home && ./ci-scripts/checkCodingFormattingRules.sh"', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
               }
             }
           }
           post {
             always {
               script {
-                myShCmd('docker cp ci-cn-clang-formatter:/home/src/oai_rules_result.txt src', new_host_flag, new_host_user, new_host)
+                myShCmd('docker cp ci-cn-clang-formatter:/home/src/oai_rules_result.txt src', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
                 // May not have been generated
                 try {
-                  myShCmd('docker cp ci-cn-clang-formatter:/home/src/oai_rules_result_list.txt src', new_host_flag, new_host_user, new_host)
+                  myShCmd('docker cp ci-cn-clang-formatter:/home/src/oai_rules_result_list.txt src', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
                 } catch (Exception e) {
                   echo "Failed to copy src/oai_rules_result_list.txt! It may not have been generated. That's OK!"
                 }
-                copyFrom2ndServer('archives/clang_format*.*', 'archives', new_host_flag, new_host_user, new_host)
-                copyFrom2ndServer('src/oai_rules*.*', 'src', new_host_flag, new_host_user, new_host)
+                copyFrom2ndServer('archives/clang_format*.*', 'archives', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
+                copyFrom2ndServer('src/oai_rules*.*', 'src', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
                 // no need to keep the clang-formatter container
-                myShCmd('docker rm -f ci-cn-clang-formatter', new_host_flag, new_host_user, new_host)
+                myShCmd('docker rm -f ci-cn-clang-formatter', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
               }
             }
           }
@@ -227,20 +276,20 @@ pipeline {
         stage('Create Docker Networks') {
           steps {
             script {
-              myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=CreateNetworks', new_host_flag, new_host_user, new_host)
+              myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=CreateNetworks', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
             }
           }
         }
         stage('Deploy OAI-SPGW-C') {
           steps {
             script {
-              myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=DeploySPGWC --tag=develop', new_host_flag, new_host_user, new_host)
+              myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=DeploySPGWC --tag=develop', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
             }
           }
           post {
             always {
               script {
-                copyFrom2ndServer('archives/spgwc_config.log', 'archives', new_host_flag, new_host_user, new_host)
+                copyFrom2ndServer('archives/spgwc_config.log', 'archives', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
               }
             }
             success {
@@ -254,15 +303,15 @@ pipeline {
         stage('Deploy OAI-SPGWU-TINY') {
           steps {
             script {
-              myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=DeploySPGWU --tag=' + spgwu_tag, new_host_flag, new_host_user, new_host)
+              myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=DeploySPGWU --tag=' + spgwu_tag, rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
             }
           }
           post {
             always {
               script {
-                myShCmd('docker cp ci-oai-spgwu:/openair-spgwu-tiny/etc/. archives/oai-spgwu-cfg', new_host_flag, new_host_user, new_host)
-                copyFrom2ndServer('archives/spgwu_config.log', 'archives', new_host_flag, new_host_user, new_host)
-                copyFrom2ndServer('archives/oai-spgwu-cfg/*.*', 'archives/oai-spgwu-cfg', new_host_flag, new_host_user, new_host)
+                myShCmd('docker cp ci-oai-spgwu:/openair-spgwu-tiny/etc/. archives/oai-spgwu-cfg', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
+                copyFrom2ndServer('archives/spgwu_config.log', 'archives', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
+                copyFrom2ndServer('archives/oai-spgwu-cfg/*.*', 'archives/oai-spgwu-cfg', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
               }
             }
             success {
@@ -278,16 +327,16 @@ pipeline {
     stage ('Start-Check-Stop OAI cNFs') {
       steps {
         script {
-          myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=StartSPGWC --tag=develop', new_host_flag, new_host_user, new_host)
+          myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=StartSPGWC --tag=develop', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
           sh "sleep 2"
-          myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=StartSPGWU --tag=' + spgwu_tag, new_host_flag, new_host_user, new_host)
+          myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=StartSPGWU --tag=' + spgwu_tag, rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
           sh "sleep 40"
-          myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=StopSPGWC --tag=develop', new_host_flag, new_host_user, new_host)
-          myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=StopSPGWU --tag=' + spgwu_tag, new_host_flag, new_host_user, new_host)
+          myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=StopSPGWC --tag=develop', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
+          myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=StopSPGWU --tag=' + spgwu_tag, rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
           sh "sleep 2"
-          myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=RetrieveLogsSPGWC --tag=develop', new_host_flag, new_host_user, new_host)
-          myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=RetrieveLogsSPGWU --tag=' + spgwu_tag, new_host_flag, new_host_user, new_host)
-          copyFrom2ndServer('archives/*_check_run.log', 'archives', new_host_flag, new_host_user, new_host)
+          myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=RetrieveLogsSPGWC --tag=develop', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
+          myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=RetrieveLogsSPGWU --tag=' + spgwu_tag, rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
+          copyFrom2ndServer('archives/*_check_run.log', 'archives', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
           sh "python3 ./ci-scripts/verifySanityCheckDeployment.py --job_name=${JOB_NAME} --job_id=${BUILD_ID}"
         }
       }
@@ -298,9 +347,9 @@ pipeline {
         }
         unsuccessful {
           // If anything wrong occurs, we still try to copy
-          myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=RetrieveLogsSPGWC --tag=develop', new_host_flag, new_host_user, new_host)
-          myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=RetrieveLogsSPGWU --tag=' + spgwu_tag, new_host_flag, new_host_user, new_host)
-          copyFrom2ndServer('archives/*_check_run.log', 'archives', new_host_flag, new_host_user, new_host)
+          myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=RetrieveLogsSPGWC --tag=develop', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
+          myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=RetrieveLogsSPGWU --tag=' + spgwu_tag, rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
+          copyFrom2ndServer('archives/*_check_run.log', 'archives', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
           sh "echo 'OAI-SPGW-C CHECK START/STOP: KO' > archives/spgwc_cnf_check_start.log"
           sh "echo 'OAI-SPGW-U CHECK START/STOP: KO' > archives/spgwu_cnf_check_start.log"
         }
@@ -310,9 +359,9 @@ pipeline {
       steps {
         script {
           // Killing all containers
-          myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=RemoveAllContainers', new_host_flag, new_host_user, new_host)
+          myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=RemoveAllContainers', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
           // Removing all intermediate networks
-          myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=RemoveNetworks', new_host_flag, new_host_user, new_host)
+          myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=RemoveNetworks', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
         }
       }
     }
@@ -381,23 +430,32 @@ pipeline {
     cleanup {
       script {
         // Killing all containers
-        myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=RemoveAllContainers', new_host_flag, new_host_user, new_host)
+        myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=RemoveAllContainers', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
         // Removing the networks
-        myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=RemoveNetworks', new_host_flag, new_host_user, new_host)
+        myShCmd('python3 ./ci-scripts/sanityCheckDeploy.py --action=RemoveNetworks', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
         // In case of build failure, we might have temporary containers still running. TBD!
 
         // Removing temporary / intermediate images
         try {
           if (env.ghprbPullId != null) {
-            myShCmd('docker image rm --force oai-spgwu-tiny:ci-temp', new_host_flag, new_host_user, new_host)
+            myShCmd('docker image rm --force oai-spgwu-tiny:ci-temp', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
+            // Currently we do not remove the temporary RHEL8 image.
+            // Can be used to be pushed to OpenShift for testing.
           }
         } catch (Exception e) {
           echo "We failed to delete the OAI-SPGWU temp image"
         }
         try {
-          myShCmd('docker image prune --force', new_host_flag, new_host_user, new_host)
+          myShCmd('docker image prune --force', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
         } catch (Exception e) {
           echo "We failed to prune all unneeded intermediate images"
+        }
+        if (rem_rhel_host_flag) {
+          try {
+            myShCmd('sudo podman image prune --force', rem_rhel_host_flag, rem_rhel_host_user, rem_rhel_host)
+          } catch (Exception e) {
+            echo "We failed to prune all unneeded intermediate images"
+          }
         }
 
         // Zipping all archived log files
@@ -514,8 +572,8 @@ def copyTo2ndServer(filename, flag, user, host) {
     sh "scp ${filename} ${user}@${host}:/tmp/CI-CN-SPGWU"
     if ("openair-spgwu.tar.bz2".equals(filename)) {
       sh "ssh ${user}@${host} 'cd /tmp/CI-CN-SPGWU && tar -xjf ${filename}'"
-      sh "ssh ${user}@${host} 'mkdir -p /tmp/CI-CN-SPGWU/archives'"
       sh "ssh ${user}@${host} 'mkdir -p /tmp/CI-CN-SPGWU/archives/oai-spgwu-cfg'"
+      sh "ssh ${user}@${host} 'rm -Rf /tmp/CI-CN-SPGWU/${filename}'"
     }
   }
 }

--- a/ci-scripts/Jenkinsfile-GitHub-Docker
+++ b/ci-scripts/Jenkinsfile-GitHub-Docker
@@ -104,9 +104,12 @@ pipeline {
             echo "PR LINK    is ${env.ghprbPullLink}"
             echo "PR TITLE   is ${env.ghprbPullTitle}"
             sh "git fetch --prune --unshallow"
+            shortenShaOne = sh returnStdout: true, script: 'git log -1 --pretty=format:"%h" ' + env.ghprbActualCommit
+            shortenShaOne = shortenShaOne.trim()
             sh "./ci-scripts/doGitHubPullRequestTempMerge.sh --src-branch ${env.ghprbSourceBranch} --src-commit ${env.ghprbActualCommit} --target-branch ${env.ghprbTargetBranch} --target-commit ${GIT_COMMIT}"
             sh "sleep 10"
             spgwu_tag = 'ci-temp'
+            rhel_spgwu_tag = 'ci-temp-pr-' + env.ghprbPullId + '-' + shortenShaOne
             spgwu_branch = env.ghprbSourceBranch
           } else {
             echo "======= THIS IS A PUSH EVENT ======"
@@ -179,6 +182,7 @@ pipeline {
                 myShCmd('sudo cp /etc/rhsm/ca/redhat-uep.pem tmp/ca', rem_rhel_host_flag, rem_rhel_host_user, rem_rhel_host)
                 myShCmd('sudo podman build --no-cache --target oai-spgwu-tiny --tag oai-spgwu-tiny:' + spgwu_tag + ' --file docker/Dockerfile.rhel8  --build-arg EURECOM_PROXY="http://proxy.eurecom.fr:8080" . > archives/spgwu_podman_image_build.log 2>&1', rem_rhel_host_flag, rem_rhel_host_user, rem_rhel_host)
                 myShCmd('sudo podman image ls >> archives/spgwu_podman_image_build.log', rem_rhel_host_flag, rem_rhel_host_user, rem_rhel_host)
+                myShCmd('sudo podman image tag oai-spgwu-tiny:' + spgwu_tag + 'oai-spgwu-tiny:' + rhel_spgwu_tag, rem_rhel_host_flag, rem_rhel_host_user, rem_rhel_host)
               }
             }
           }
@@ -439,8 +443,7 @@ pipeline {
         try {
           if (env.ghprbPullId != null) {
             myShCmd('docker image rm --force oai-spgwu-tiny:ci-temp', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
-            // Currently we do not remove the temporary RHEL8 image.
-            // Can be used to be pushed to OpenShift for testing.
+            myShCmd('sudo podman image rm oai-spgwu-tiny:' + spgwu_tag, rem_rhel_host_flag, rem_rhel_host_user, rem_rhel_host)
           }
         } catch (Exception e) {
           echo "We failed to delete the OAI-SPGWU temp image"

--- a/ci-scripts/Jenkinsfile-GitHub-Docker
+++ b/ci-scripts/Jenkinsfile-GitHub-Docker
@@ -141,7 +141,7 @@ pipeline {
                 myShCmd('docker image rm oai-spgwu-tiny:develop', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
               }
               myShCmd('docker image prune --force', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
-              myShCmd('docker build --target oai-spgwu-tiny --tag oai-spgwu-tiny:' + spgwu_tag + ' --file docker/Dockerfile.ubuntu18.04 --build-arg EURECOM_PROXY="http://proxy.eurecom.fr:8080" . > archives/spgwu_docker_image_build.log 2>&1', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
+              myShCmd('docker build --no-cache --target oai-spgwu-tiny --tag oai-spgwu-tiny:' + spgwu_tag + ' --file docker/Dockerfile.ubuntu18.04 --build-arg EURECOM_PROXY="http://proxy.eurecom.fr:8080" . > archives/spgwu_docker_image_build.log 2>&1', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
               myShCmd('docker image ls >> archives/spgwu_docker_image_build.log', rem_u18_host_flag, rem_u18_host_user, rem_u18_host)
             }
           }
@@ -177,7 +177,7 @@ pipeline {
                 myShCmd('mkdir -p tmp/ca tmp/entitlement', rem_rhel_host_flag, rem_rhel_host_user, rem_rhel_host)
                 myShCmd('cp /etc/pki/entitlement/*pem tmp/entitlement', rem_rhel_host_flag, rem_rhel_host_user, rem_rhel_host)
                 myShCmd('sudo cp /etc/rhsm/ca/redhat-uep.pem tmp/ca', rem_rhel_host_flag, rem_rhel_host_user, rem_rhel_host)
-                myShCmd('sudo podman build --target oai-spgwu-tiny --tag oai-spgwu-tiny:' + spgwu_tag + ' --file docker/Dockerfile.rhel8  --build-arg EURECOM_PROXY="http://proxy.eurecom.fr:8080" . > archives/spgwu_podman_image_build.log 2>&1', rem_rhel_host_flag, rem_rhel_host_user, rem_rhel_host)
+                myShCmd('sudo podman build --no-cache --target oai-spgwu-tiny --tag oai-spgwu-tiny:' + spgwu_tag + ' --file docker/Dockerfile.rhel8  --build-arg EURECOM_PROXY="http://proxy.eurecom.fr:8080" . > archives/spgwu_podman_image_build.log 2>&1', rem_rhel_host_flag, rem_rhel_host_user, rem_rhel_host)
                 myShCmd('sudo podman image ls >> archives/spgwu_podman_image_build.log', rem_rhel_host_flag, rem_rhel_host_user, rem_rhel_host)
               }
             }

--- a/docker/Dockerfile.rhel8
+++ b/docker/Dockerfile.rhel8
@@ -1,0 +1,105 @@
+#/*
+# * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
+# * contributor license agreements.  See the NOTICE file distributed with
+# * this work for additional information regarding copyright ownership.
+# * The OpenAirInterface Software Alliance licenses this file to You under
+# * the OAI Public License, Version 1.1  (the "License"); you may not use this file
+# * except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# *      http://www.openairinterface.org/?page_id=698
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# *-------------------------------------------------------------------------------
+# * For more information about the OpenAirInterface (OAI) Software Alliance:
+# *      contact@openairinterface.org
+# */
+#---------------------------------------------------------------------
+#
+# Dockerfile for the Open-Air-Interface SPGW-U-TINY service
+#   Valid for RHEL8
+#
+#---------------------------------------------------------------------
+
+#---------------------------------------------------------------------
+# BUILDER IMAGE
+#---------------------------------------------------------------------
+FROM registry.access.redhat.com/ubi8/ubi:latest as oai-spgwu-tiny-builder
+
+# Entitlements and RHSM configurations are Open-Shift Secret and ConfigMaps
+# It is pre-requisite
+# Copy the entitlements
+COPY tmp/entitlement/*.pem /etc/pki/entitlement
+# Copy the subscription manager configurations
+COPY tmp/ca/redhat-uep.pem /etc/rhsm/ca
+
+RUN rm /etc/rhsm-host && \
+    # Initialize /etc/yum.repos.d/redhat.repo
+    # See https://access.redhat.com/solutions/1443553
+    yum repolist --disablerepo=* && \
+    subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms && \
+    yum update -y && \
+    yum -y install --enablerepo="codeready-builder-for-rhel-8-x86_64-rpms" \
+       # diff, cmp and file are not in the ubi???
+       diffutils \
+       file \
+       psmisc \
+       git
+
+# Copy the workspace as is
+WORKDIR /openair-spgwu-tiny
+COPY . /openair-spgwu-tiny
+
+# Installing and Building SPGW-U-TINY
+WORKDIR /openair-spgwu-tiny/build/scripts
+RUN ./build_spgwu --install-deps --force
+RUN ./build_spgwu --clean --build-type Release --jobs --Verbose
+
+#---------------------------------------------------------------------
+# TARGET IMAGE
+#---------------------------------------------------------------------
+FROM registry.access.redhat.com/ubi8/ubi:latest as oai-spgwu-tiny
+ENV TZ=Europe/Paris
+# We install some debug tools for the moment in addition of mandatory libraries
+RUN yum update -y && \
+    yum -y install --enablerepo="ubi-8-codeready-builder" \
+      tzdata \
+      psmisc \
+      net-tools \
+      ethtool \
+      iproute \
+      iptables \
+      initscripts \
+      libevent && \
+    yum clean all -y && \
+    rm -rf /var/cache/yum
+
+# Copying executable and generated libraries
+WORKDIR /openair-spgwu-tiny/bin
+COPY --from=oai-spgwu-tiny-builder /openair-spgwu-tiny/build/spgw_u/build/spgwu oai_spgwu
+COPY --from=oai-spgwu-tiny-builder /openair-spgwu-tiny/scripts/entrypoint.sh .
+
+# Copying installed libraries from builder
+COPY --from=oai-spgwu-tiny-builder /lib64/libgflags.so.2.1 /lib64/
+COPY --from=oai-spgwu-tiny-builder /lib64/libglog.so.0 /lib64/
+COPY --from=oai-spgwu-tiny-builder /lib64/libdouble-conversion.so.1 /lib64/
+COPY --from=oai-spgwu-tiny-builder /lib64/libconfig++.so.9 /lib64/
+COPY --from=oai-spgwu-tiny-builder /lib64/libboost_system.so.1.66.0 /lib64/
+RUN ldconfig
+
+# Copying template configuration files
+# The configuration folder will be flat
+WORKDIR /openair-spgwu-tiny/etc
+COPY --from=oai-spgwu-tiny-builder /openair-spgwu-tiny/etc/spgw_u.conf .
+
+WORKDIR /openair-spgwu-tiny
+
+# expose ports
+EXPOSE 2152/udp 8805/udp
+
+CMD ["/openair-spgwu-tiny/bin/oai_spgwu", "-c", "/openair-spgwu-tiny/etc/spgw_u.conf", "-o"]
+ENTRYPOINT ["/openair-spgwu-tiny/bin/entrypoint.sh"]


### PR DESCRIPTION
The idea is to native and automatically handle the generation of `RHEL8` images:

- There will be a build on each pull request
- There will be the sanity check deployment to quickly see if the image is not corrupted
- But contrary to the `Ubuntu18` path, let's keep the temporary built image on RHEL8
  * Let tag it like oai-spgwu-tiny:prID-shirtCommitID
  * So developer and devOps team can use that temporary image, push it to the OpenShiftCluster and test it there
  * Once the Pull Request is merged, a new `develop` image will be generated and will be used to push into the production OC project

This framework will be duplicated for all CN4G components (included the MAGMA MME) and the CN5G components
