### PR TITLE
Handle assoc req

### DIFF
--- a/src/spgwu/spgwu_pfcp_association.cpp
+++ b/src/spgwu/spgwu_pfcp_association.cpp
@@ -97,6 +97,7 @@ bool pfcp_associations::add_association(
   }
   return false;
 }
+
 //------------------------------------------------------------------------------
 bool pfcp_associations::get_association(
     const pfcp::node_id_t& node_id,

--- a/src/spgwu/spgwu_sx.cpp
+++ b/src/spgwu/spgwu_sx.cpp
@@ -339,6 +339,7 @@ void spgwu_sx::handle_receive_association_setup_response(
 
 void spgwu_sx::handle_receive_association_setup_request(
     pfcp::pfcp_msg& msg, const endpoint& remote_endpoint) {
+Logger::spgwu_sx().info("Handle SX ASSOCIATION SETUP REQUEST");
   bool error                                       = true;
   uint64_t trxn_id                                 = 0;
   pfcp_association_setup_request msg_ies_container = {};
@@ -388,7 +389,7 @@ void spgwu_sx::handle_receive_association_setup_request(
       a.pfcp_ies.set(up_function_features);
       if (node_id.node_id_type == pfcp::NODE_ID_TYPE_IPV4_ADDRESS) {
         a.r_endpoint = remote_endpoint;
-        send_sx_msg(a);
+	send_sx_msg(a);
       } else {
         Logger::spgwu_sx().warn(
             "Received SX ASSOCIATION SETUP REQUEST node_id IPV6, FQDN!, "
@@ -401,11 +402,6 @@ void spgwu_sx::handle_receive_association_setup_request(
           "ignore message");
       return;
     }
-
-    //	    if (restore_n4_sessions) {
-    //	      pfcp_associations::get_instance().restore_n4_sessions(
-    //	          msg_ies_container.node_id.second);
-    //	    }
   }
 }
 //------------------------------------------------------------------------------
@@ -603,6 +599,10 @@ void spgwu_sx::handle_itti_msg(itti_sxab_session_deletion_response& msg) {
 //------------------------------------------------------------------------------
 void spgwu_sx::send_sx_msg(itti_sxab_association_setup_request& i) {
   send_request(i.r_endpoint, i.pfcp_ies, TASK_SPGWU_SX, i.trxn_id);
+}
+//------------------------------------------------------------------------------
+void spgwu_sx::send_sx_msg(itti_sxab_association_setup_response& i) {
+  send_response(i.r_endpoint, i.pfcp_ies, i.trxn_id);
 }
 //------------------------------------------------------------------------------
 void spgwu_sx::send_sx_msg(itti_sxab_session_establishment_response& i) {

--- a/src/spgwu/spgwu_sx.cpp
+++ b/src/spgwu/spgwu_sx.cpp
@@ -339,7 +339,7 @@ void spgwu_sx::handle_receive_association_setup_response(
 
 void spgwu_sx::handle_receive_association_setup_request(
     pfcp::pfcp_msg& msg, const endpoint& remote_endpoint) {
-Logger::spgwu_sx().info("Handle SX ASSOCIATION SETUP REQUEST");
+  Logger::spgwu_sx().info("Handle SX ASSOCIATION SETUP REQUEST");
   bool error                                       = true;
   uint64_t trxn_id                                 = 0;
   pfcp_association_setup_request msg_ies_container = {};
@@ -383,13 +383,13 @@ Logger::spgwu_sx().info("Handle SX ASSOCIATION SETUP REQUEST");
     pfcp::node_id_t node_id = {};
     if (spgwu_cfg.get_pfcp_node_id(node_id) == RETURNok) {
       a.pfcp_ies.set(node_id);
-      pfcp::recovery_time_stamp_t r = {.recovery_time_stamp =
-                                           (uint32_t) recovery_time_stamp};
+      pfcp::recovery_time_stamp_t r = {
+          .recovery_time_stamp = (uint32_t) recovery_time_stamp};
       a.pfcp_ies.set(r);
       a.pfcp_ies.set(up_function_features);
-      if (node_id.node_id_type != pfcp::NODE_ID_TYPE_IPV6_ADDRESS){
+      if (node_id.node_id_type != pfcp::NODE_ID_TYPE_IPV6_ADDRESS) {
         a.r_endpoint = remote_endpoint;
-	send_sx_msg(a);
+        send_sx_msg(a);
       } else {
         Logger::spgwu_sx().warn(
             "Received SX ASSOCIATION SETUP REQUEST node_id IPV6, FQDN!, "
@@ -630,8 +630,8 @@ void spgwu_sx::start_association(const pfcp::node_id_t& node_id) {
   pfcp::node_id_t this_node_id = {};
   if (spgwu_cfg.get_pfcp_node_id(this_node_id) == RETURNok) {
     a.pfcp_ies.set(this_node_id);
-    pfcp::recovery_time_stamp_t r = {.recovery_time_stamp =
-                                         (uint32_t) recovery_time_stamp};
+    pfcp::recovery_time_stamp_t r = {
+        .recovery_time_stamp = (uint32_t) recovery_time_stamp};
     a.pfcp_ies.set(r);
     a.pfcp_ies.set(up_function_features);
     if (node_id.node_id_type == pfcp::NODE_ID_TYPE_IPV4_ADDRESS) {
@@ -673,8 +673,8 @@ void spgwu_sx::send_sx_msg(
 //------------------------------------------------------------------------------
 void spgwu_sx::send_heartbeat_request(std::shared_ptr<pfcp_association>& a) {
   pfcp::pfcp_heartbeat_request h = {};
-  pfcp::recovery_time_stamp_t r  = {.recovery_time_stamp =
-                                       (uint32_t) recovery_time_stamp};
+  pfcp::recovery_time_stamp_t r  = {
+      .recovery_time_stamp = (uint32_t) recovery_time_stamp};
   h.set(r);
 
   pfcp::node_id_t& node_id = a->node_id;
@@ -696,8 +696,8 @@ void spgwu_sx::send_heartbeat_request(std::shared_ptr<pfcp_association>& a) {
 void spgwu_sx::send_heartbeat_response(
     const endpoint& r_endpoint, const uint64_t trxn_id) {
   pfcp::pfcp_heartbeat_response h = {};
-  pfcp::recovery_time_stamp_t r   = {.recovery_time_stamp =
-                                       (uint32_t) recovery_time_stamp};
+  pfcp::recovery_time_stamp_t r   = {
+      .recovery_time_stamp = (uint32_t) recovery_time_stamp};
   h.set(r);
   send_response(r_endpoint, h, trxn_id);
 }

--- a/src/spgwu/spgwu_sx.cpp
+++ b/src/spgwu/spgwu_sx.cpp
@@ -383,8 +383,8 @@ void spgwu_sx::handle_receive_association_setup_request(
     pfcp::node_id_t node_id = {};
     if (spgwu_cfg.get_pfcp_node_id(node_id) == RETURNok) {
       a.pfcp_ies.set(node_id);
-      pfcp::recovery_time_stamp_t r = {
-          .recovery_time_stamp = (uint32_t) recovery_time_stamp};
+      pfcp::recovery_time_stamp_t r = {.recovery_time_stamp =
+                                           (uint32_t) recovery_time_stamp};
       a.pfcp_ies.set(r);
       a.pfcp_ies.set(up_function_features);
       if (node_id.node_id_type != pfcp::NODE_ID_TYPE_IPV6_ADDRESS) {
@@ -630,8 +630,8 @@ void spgwu_sx::start_association(const pfcp::node_id_t& node_id) {
   pfcp::node_id_t this_node_id = {};
   if (spgwu_cfg.get_pfcp_node_id(this_node_id) == RETURNok) {
     a.pfcp_ies.set(this_node_id);
-    pfcp::recovery_time_stamp_t r = {
-        .recovery_time_stamp = (uint32_t) recovery_time_stamp};
+    pfcp::recovery_time_stamp_t r = {.recovery_time_stamp =
+                                         (uint32_t) recovery_time_stamp};
     a.pfcp_ies.set(r);
     a.pfcp_ies.set(up_function_features);
     if (node_id.node_id_type == pfcp::NODE_ID_TYPE_IPV4_ADDRESS) {
@@ -673,8 +673,8 @@ void spgwu_sx::send_sx_msg(
 //------------------------------------------------------------------------------
 void spgwu_sx::send_heartbeat_request(std::shared_ptr<pfcp_association>& a) {
   pfcp::pfcp_heartbeat_request h = {};
-  pfcp::recovery_time_stamp_t r  = {
-      .recovery_time_stamp = (uint32_t) recovery_time_stamp};
+  pfcp::recovery_time_stamp_t r  = {.recovery_time_stamp =
+                                       (uint32_t) recovery_time_stamp};
   h.set(r);
 
   pfcp::node_id_t& node_id = a->node_id;
@@ -696,8 +696,8 @@ void spgwu_sx::send_heartbeat_request(std::shared_ptr<pfcp_association>& a) {
 void spgwu_sx::send_heartbeat_response(
     const endpoint& r_endpoint, const uint64_t trxn_id) {
   pfcp::pfcp_heartbeat_response h = {};
-  pfcp::recovery_time_stamp_t r   = {
-      .recovery_time_stamp = (uint32_t) recovery_time_stamp};
+  pfcp::recovery_time_stamp_t r   = {.recovery_time_stamp =
+                                       (uint32_t) recovery_time_stamp};
   h.set(r);
   send_response(r_endpoint, h, trxn_id);
 }

--- a/src/spgwu/spgwu_sx.cpp
+++ b/src/spgwu/spgwu_sx.cpp
@@ -387,7 +387,7 @@ Logger::spgwu_sx().info("Handle SX ASSOCIATION SETUP REQUEST");
                                            (uint32_t) recovery_time_stamp};
       a.pfcp_ies.set(r);
       a.pfcp_ies.set(up_function_features);
-      if (node_id.node_id_type == pfcp::NODE_ID_TYPE_IPV4_ADDRESS) {
+      if (node_id.node_id_type != pfcp::NODE_ID_TYPE_IPV6_ADDRESS){
         a.r_endpoint = remote_endpoint;
 	send_sx_msg(a);
       } else {

--- a/src/spgwu/spgwu_sx.hpp
+++ b/src/spgwu/spgwu_sx.hpp
@@ -76,7 +76,7 @@ class spgwu_sx : public pfcp::pfcp_l4_stack {
   void send_sx_msg(itti_sxab_heartbeat_request& s){};
   void send_sx_msg(itti_sxab_heartbeat_response& s){};
   void send_sx_msg(itti_sxab_association_setup_request& s);
-  void send_sx_msg(itti_sxab_association_setup_response& s){};
+  void send_sx_msg(itti_sxab_association_setup_response& s);
   void send_sx_msg(itti_sxab_association_update_request& s){};
   void send_sx_msg(itti_sxab_association_update_response& s){};
   void send_sx_msg(itti_sxab_association_release_request& s){};

--- a/src/spgwu/spgwu_sx.hpp
+++ b/src/spgwu/spgwu_sx.hpp
@@ -109,7 +109,8 @@ class spgwu_sx : public pfcp::pfcp_l4_stack {
       pfcp::pfcp_msg& msg, const endpoint& remote_endpoint);
   void handle_receive_association_setup_response(
       pfcp::pfcp_msg& msg, const endpoint& remote_endpoint);
-  void handle_receive_association_setup_request(pfcp::pfcp_msg& msg, const endpoint& remote_endpoint);
+  void handle_receive_association_setup_request(
+      pfcp::pfcp_msg& msg, const endpoint& remote_endpoint);
   // session related
   void handle_receive_session_establishment_request(
       pfcp::pfcp_msg& msg, const endpoint& remote_endpoint);

--- a/src/spgwu/spgwu_sx.hpp
+++ b/src/spgwu/spgwu_sx.hpp
@@ -109,6 +109,7 @@ class spgwu_sx : public pfcp::pfcp_l4_stack {
       pfcp::pfcp_msg& msg, const endpoint& remote_endpoint);
   void handle_receive_association_setup_response(
       pfcp::pfcp_msg& msg, const endpoint& remote_endpoint);
+  void handle_receive_association_setup_request(pfcp::pfcp_msg& msg, const endpoint& remote_endpoint);
   // session related
   void handle_receive_session_establishment_request(
       pfcp::pfcp_msg& msg, const endpoint& remote_endpoint);


### PR DESCRIPTION
TS 29.244, R 16.05
Section 6.2.6 PFCP Association Setup Procedure -
The CP function and the UP function shall support the PFCP Association Setup procedure initiated by the CP function
(see clause 6.2.6.2). 
The CP function and the UP function may additionally support the PFCP Association Setup
procedure initiated by the UP function (see clause 6.2.6.3).
