### PR TITLE
added partial httpv2 support

### DIFF
--- a/etc/spgw_u.conf
+++ b/etc/spgw_u.conf
@@ -123,6 +123,7 @@ SPGW-U =
        {
           IPV4_ADDRESS = "@NRF_IPV4_ADDRESS@";  # YOUR NRF CONFIG HERE
           PORT         = @NRF_PORT@;            # YOUR NRF CONFIG HERE (default: 80)
+          HTTP_VERSION = @HTTP_VERSION@;   #Set HTTP version for NRF (1 or 2)Default 1
           API_VERSION  = "@NRF_API_VERSION@";   # YOUR NRF API VERSION HERE
           FQDN = "@NRF_FQDN@";
        };

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -25,6 +25,7 @@ NSSAI_SST_0=${NSSAI_SST_0:-1}
 NSSAI_SD_0=${NSSAI_SD_0:-2}
 DNN_0=${DNN_0:-default}
 UPF_FQDN_5G=${UPF_FQDN_5G:-oai-spgwu-tiny-svc}
+HTTP_VERSION=${HTTP_VERSION:-1}
 
 # Default values
 if [[ ${ENABLE_5G_FEATURES} == "yes" ]];then

--- a/src/spgwu/spgwu_config.cpp
+++ b/src/spgwu/spgwu_config.cpp
@@ -533,9 +533,18 @@ int spgwu_config::load(const string& config_file) {
       const Setting& nrf_cfg =
           support_features[SPGWU_CONFIG_STRING_5G_FEATURES_NRF];
       struct in_addr nrf_ipv4_addr;
-      unsigned int nrf_port = 0;
+      unsigned int nrf_port    = 0;
+      unsigned int httpVersion = 0;
       std::string nrf_api_version;
       string nrf_address = {};
+
+      if (!(nrf_cfg.lookupValue(
+              SPGWU_CONFIG_STRING_5G_FEATURES_NRF_HTTP_VERSION, httpVersion))) {
+        Logger::spgwu_app().error(
+            SPGWU_CONFIG_STRING_5G_FEATURES_NRF_HTTP_VERSION "failed");
+        throw(SPGWU_CONFIG_STRING_5G_FEATURES_NRF_HTTP_VERSION "failed");
+      }
+      upf_5g_features.nrf_addr.http_version = httpVersion;
 
       if (!upf_5g_features.use_fqdn_nrf) {
         nrf_cfg.lookupValue(

--- a/src/spgwu/spgwu_config.hpp
+++ b/src/spgwu/spgwu_config.hpp
@@ -82,6 +82,7 @@ namespace spgwu {
 #define SPGWU_CONFIG_STRING_5G_FEATURES_NRF "NRF"
 #define SPGWU_CONFIG_STRING_5G_FEATURES_NRF_IPV4_ADDRESS "IPV4_ADDRESS"
 #define SPGWU_CONFIG_STRING_5G_FEATURES_NRF_PORT "PORT"
+#define SPGWU_CONFIG_STRING_5G_FEATURES_NRF_HTTP_VERSION "HTTP_VERSION"
 #define SPGWU_CONFIG_STRING_5G_FEATURES_NRF_API_VERSION "API_VERSION"
 #define SPGWU_CONFIG_STRING_5G_FEATURES_UPF_INFO "UPF_INFO"
 #define SPGWU_CONFIG_STRING_5G_FEATURES_NSSAI_SST "NSSAI_SST"
@@ -161,6 +162,7 @@ class spgwu_config {
     struct {
       struct in_addr ipv4_addr;
       unsigned int port;
+      unsigned int http_version;
       std::string api_version;
       std::string fqdn;
     } nrf_addr;

--- a/src/spgwu/spgwu_nrf.cpp
+++ b/src/spgwu/spgwu_nrf.cpp
@@ -299,6 +299,14 @@ void spgwu_nrf::send_curl(
         curl, CURLOPT_INTERFACE,
         spgwu_cfg.sx.if_name.c_str());  // TODO: use another interface for UPF
                                         // to communicate with NRF
+    if (spgwu_cfg.upf_5g_features.nrf_addr.http_version == 2) {
+      curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+      // We use a self-signed test server, skip verification during debugging
+      curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
+      curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+      curl_easy_setopt(
+          curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE);
+    }
 
     // Response information
     long code = {0};


### PR DESCRIPTION
Tested httpv2 with setting `USE_FQDN_NRF=no`.
When `USE_FQDN_NRF=yes`, we need to distinguish between httpv1 and httpv2 port from resolved FQDN endpoint.