### PR TITLE
fix GTPU DL encapsulation 8 extraneous bytes

### DIFF
--- a/src/gtpv1u/gtpv1u.cpp
+++ b/src/gtpv1u/gtpv1u.cpp
@@ -179,7 +179,7 @@ void gtpu_l4_stack::send_g_pdu(
     // gtpuhdr->next_ext_type  = GTPU_NO_MORE_EXTENSION_HEADER;
     udp_s.async_send_to(
         reinterpret_cast<const char*>(gtpuhdr),
-        payload_len + sizeof(struct gtpuhdr) + 4, peer_addr);
+        payload_len + sizeof(struct gtpuhdr) - 4, peer_addr);
   } else {
     struct gtpuhdr* gtpuhdr = reinterpret_cast<struct gtpuhdr*>(
         reinterpret_cast<uintptr_t>(payload) -


### PR DESCRIPTION
Quick fix for removing extra leading bytes on Downling GTPU tunnel