### PR TITLE
Multi spgwu rebase develop

### DIFF
--- a/build/scripts/build_helper
+++ b/build/scripts/build_helper
@@ -127,6 +127,7 @@ check_supported_distribution() {
     local distribution=$(get_distribution_release)
     case "$distribution" in
         "ubuntu18.04") return 0 ;;
+        "ubuntu20.04") return 0 ;;
         "rhel8")       return 0 ;;
         "rhel8.2")     return 0 ;;
         "rhel8.3")     return 0 ;;

--- a/build/scripts/build_helper.fb_folly
+++ b/build/scripts/build_helper.fb_folly
@@ -68,7 +68,6 @@ install_fb_folly_from_source(){
       $SUDO $INSTALLER install $OPTION \
         g++ \
         cmake \
-        libboost1.67-dev \
         libevent-dev \
         libdouble-conversion-dev \
         libgoogle-glog-dev \
@@ -87,7 +86,16 @@ install_fb_folly_from_source(){
     fi
 
     pushd /tmp
-
+    git clone https://github.com/fmtlib/fmt.git && \
+    cd fmt && \
+    mkdir _build && cd _build && \
+    cmake .. && \
+    make -j$(nproc) && \
+    $SUDO make install
+    
+    popd
+    pushd /tmp
+    
     if [ $debug -eq 1 ]; then
       # For advanced debugging options
       $SUDO $INSTALLER install $OPTION \
@@ -132,7 +140,7 @@ install_fb_folly_from_source(){
     else
       case "$(get_distribution_release)" in
         "ubuntu20.04")
-          git checkout -f v2021.04.26.00
+          git checkout -f v2021.09.27.00
         ;;
         *)
           git checkout -f v2019.11.11.00

--- a/build/scripts/build_helper.fb_folly
+++ b/build/scripts/build_helper.fb_folly
@@ -130,7 +130,14 @@ install_fb_folly_from_source(){
       echo '     message(STATUS "Found gflags from package config ${gflags_CONFIG}")' >> patch.diff
       git apply patch.diff
     else
-        git checkout -f v2019.11.11.00
+      case "$(get_distribution_release)" in
+        "ubuntu20.04")
+          git checkout -f v2021.04.26.00
+        ;;
+        *)
+          git checkout -f v2019.11.11.00
+        ;;
+      esac
     fi
     mkdir _build && cd _build
     if [[ "$OS_BASEDISTRO" == "fedora" ]]; then

--- a/build/scripts/build_helper.spgw
+++ b/build/scripts/build_helper.spgw
@@ -411,9 +411,12 @@ check_install_spgwu_min_deps() {
   # Networking
   if [[ $OS_DISTRO == "ubuntu" ]]; then
     case "$(get_distribution_release)" in
-  "ubuntu18.04")
-      specific_packages="iproute2"
-      ;;
+      "ubuntu18.04")
+        specific_packages="iproute2"
+        ;;
+      "ubuntu20.04")
+        specific_packages="iproute2"
+        ;;
     esac
     PACKAGE_LIST="\
       $specific_packages \

--- a/build/scripts/build_helper.spgw
+++ b/build/scripts/build_helper.spgw
@@ -65,6 +65,55 @@ install_fmt() {
   fi
   return 0
 }
+
+#-------------------------------------------------------------------------------
+#arg1 is force (0 or 1) (no interactive script)
+#arg2 is debug (0 or 1) (install debug libraries)
+install_pistache_from_git() {
+  if [ $1 -eq 0 ]; then
+    read -p "Do you want to install Pistache ? <y/N> " prompt
+    OPTION="-y"
+  else
+    prompt='y'
+    OPTION="-y"
+  fi
+  if [ $2 -eq 0 ]; then
+    debug=0
+  else
+    debug=1
+  fi
+
+  if [[ $prompt =~ [yY](es)* ]]
+  then
+    GIT_URL=https://github.com/oktal/pistache.git
+    echo "Install Pistache from $GIT_URL"
+    pushd $OPENAIRCN_DIR/build/ext
+    echo "Downloading Pistache"
+    if [[ $OPTION =~ -[yY](es)* ]]
+    then
+      $SUDO rm -rf pistache
+    fi
+
+    git clone $GIT_URL
+    git submodule update --init
+    cd pistache && git checkout e18ed9baeb2145af6f9ea41246cf48054ffd9907
+    ret=$?;[[ $ret -ne 0 ]] && popd && return $ret
+    mkdir _build && cd _build
+    $CMAKE -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release \
+        -DPISTACHE_BUILD_EXAMPLES=false \
+        -DPISTACHE_BUILD_TESTS=false \
+        -DPISTACHE_BUILD_DOCS=false \
+        .. 
+    ret=$?;[[ $ret -ne 0 ]] && popd && return $ret
+    make -j `nproc`
+    ret=$?;[[ $ret -ne 0 ]] && popd && return $ret
+    $SUDO make install
+    ret=$?;[[ $ret -ne 0 ]] && popd && return $ret
+    popd
+  fi
+  return 0
+}
+
 #-------------------------------------------------------------------------------
 #arg1 is force (0 or 1) (no interactive script)
 #arg2 is debug (0 or 1) (install debug libraries)
@@ -230,19 +279,22 @@ check_install_spgwu_deps() {
         # PPA has 1.67
         $SUDO add-apt-repository ppa:mhier/libboost-latest --yes
         $SUDO $INSTALLER update
-        specific_packages="libconfig++-dev libboost1.67-dev"
+        specific_packages="libconfig++-dev libasio-dev libboost1.67-dev libgcrypt11-dev"
+        ;;
+      "ubuntu20.04")
+        specific_packages="libconfig++-dev libasio-dev libboost-all-dev libgcrypt20-dev"
         ;;
       *)
         specific_packages="libconfig++-dev libasio-dev libboost-all-dev"
         ;;
     esac
+
     # removed libspdlog-dev
     PACKAGE_LIST="\
       $specific_packages \
       guile-2.0-dev \
       libcurl4-gnutls-dev \
       libevent-dev \
-      libgcrypt11-dev \
       libgmp-dev \
       libhogweed? \
       libidn2-0-dev \
@@ -253,6 +305,7 @@ check_install_spgwu_deps() {
       libxml2 \
       libxml2-dev \
       openssl \
+      rapidjson-dev \
       python \
       libcurl4 \
       wget \
@@ -280,6 +333,7 @@ check_install_spgwu_deps() {
       libxml2 \
       libxml2-devel \
       openssl \
+      rapidjson \
       check \
       python2 \
       libcurl-devel \
@@ -304,6 +358,9 @@ check_install_spgwu_deps() {
   ret=$?;[[ $ret -ne 0 ]] && return $ret
   
   install_nlohmann_from_git $1 $2
+  ret=$?;[[ $ret -ne 0 ]] && return $ret
+  
+  install_pistache_from_git $1 $2
   ret=$?;[[ $ret -ne 0 ]] && return $ret
 
   return 0

--- a/docker/Dockerfile.debug.centos8
+++ b/docker/Dockerfile.debug.centos8
@@ -63,5 +63,3 @@ WORKDIR /openair-spgwu-tiny
 EXPOSE 2152/udp 8805/udp 22/tcp
 
 
-CMD ["/openair-spgwu-tiny/bin/oai_spgwu", "-c", "/openair-spgwu-tiny/etc/spgw_u.conf", "-o"]
-ENTRYPOINT ["/openair-spgwu-tiny/bin/entrypoint.sh"]

--- a/docker/Dockerfile.debug.centos8.3dparty
+++ b/docker/Dockerfile.debug.centos8.3dparty
@@ -58,8 +58,10 @@ RUN yum update -y \
     openssh-server \
     procps-ng \  
   && yum clean all -y \
-  && rm -rf /var/cache/yum
-
+  && rm -rf /var/cache/yum \
+  && echo "/usr/local/lib" > /etc/ld.so.conf.d/local-lib.conf \
+  && echo "/usr/local/lib64" >> /etc/ld.so.conf.d/local-lib.conf 
+  
 # Some GIT configuration command quite useful
 RUN /bin/bash -c "if [[ -v HTTP_PROXY ]]; then git config --global http.proxy $HTTP_PROXY; fi"
 RUN git config --global https.postBuffer 123289600
@@ -70,4 +72,9 @@ COPY ./ /openair-spgwu-tiny
 
 # Installing and Building SPGW-U
 WORKDIR /openair-spgwu-tiny/build/scripts
-RUN ./build_spgwu --install-deps --force
+RUN ./build_spgwu --install-deps --force && ldconfig
+
+# For docker-compose, waiting for other nodes to start
+WORKDIR /
+RUN git clone https://github.com/vishnubob/wait-for-it.git
+

--- a/etc/spgw_u.conf
+++ b/etc/spgw_u.conf
@@ -23,7 +23,7 @@ SPGW-U =
     FQDN = "gw@GW_ID@.spgw.node.epc.mnc@MNC03@.mcc@MCC@.@REALM@"; # FQDN for 4G
     INSTANCE                       = 0;            # 0 is the default
     PID_DIRECTORY                  = "@PID_DIRECTORY@";     # /var/run is the default
-
+    REST_PORT                      = 9081;
     #ITTI_TASKS :
     #{
         #ITTI_TIMER_SCHED_PARAMS :

--- a/etc/spgw_u.conf
+++ b/etc/spgw_u.conf
@@ -109,6 +109,8 @@ SPGW-U =
     NON_STANDART_FEATURES :
     {
         BYPASS_UL_PFCP_RULES = "@BYPASS_UL_PFCP_RULES@"; # 'no' for standard features, yes for enhancing UL throughput
+        TCP_MSS_CLAMPING = "@TCP_MSS_CLAMPING@"; # 'yes' for clamping UE TCP traffic to a specific value
+        TCP_MSS          = @TCP_MSS@; # set here UE MTU minus 20 bytes
     };
 
     SUPPORT_5G_FEATURES:  

--- a/src/oai_spgwu/CMakeLists.txt
+++ b/src/oai_spgwu/CMakeLists.txt
@@ -286,6 +286,7 @@ include_directories(${SRC_TOP_DIR}/../build/ext/spdlog/include)
 add_executable(spgwu
   ${SRC_TOP_DIR}/oai_spgwu/main.cpp
   ${SRC_TOP_DIR}/oai_spgwu/options.cpp
+  ${SRC_TOP_DIR}/oai_spgwu/rest_handler.cpp
   ${SRC_TOP_DIR}/itti/itti.cpp
   ${SRC_TOP_DIR}/itti/itti_msg.cpp
   )
@@ -300,5 +301,5 @@ ENDIF(STATIC_LINKING)
 
 # folly glog dl double-conversion for FB folly library
 target_link_libraries (spgwu ${ASAN}  -Wl,--start-group CN_UTILS SPGWU SPGW_SWITCH UDP GTPV1U PFCP 3GPP_COMMON_TYPES gflags glog dl double-conversion folly -Wl,--end-group
-pthread m rt config++  event boost_system curl)
+pthread m rt config++  event boost_system curl pistache)
 

--- a/src/oai_spgwu/CMakeLists.txt
+++ b/src/oai_spgwu/CMakeLists.txt
@@ -301,5 +301,5 @@ ENDIF(STATIC_LINKING)
 
 # folly glog dl double-conversion for FB folly library
 target_link_libraries (spgwu ${ASAN}  -Wl,--start-group CN_UTILS SPGWU SPGW_SWITCH UDP GTPV1U PFCP 3GPP_COMMON_TYPES gflags glog dl double-conversion folly -Wl,--end-group
-pthread m rt config++  event boost_system curl pistache)
+pthread m rt config++  event boost_system curl pistache fmt)
 

--- a/src/oai_spgwu/rest_handler.cpp
+++ b/src/oai_spgwu/rest_handler.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2017 Sprint
+ *
+ * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The OpenAirInterface Software Alliance licenses this file to You under
+ * the terms found in the LICENSE file in the root of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "logger.hpp"
+#include "rest_handler.h"
+
+#include "rapidjson/error/en.h"
+
+#include <pistache/endpoint.h>
+
+void RestHandler::onRequest(
+    const Pistache::Http::Request& request,
+    Pistache::Http::ResponseWriter response) {
+  std::cout << request.resource() << std::endl;
+  std::cout << request.method() << std::endl;
+  std::cout << request.body() << std::endl;
+
+  if (request.resource() == "/status") {
+    RAPIDJSON_NAMESPACE::Document doc;
+    std::string keyschema("userschema");
+
+    doc.Parse(request.body().c_str());
+    if (doc.HasParseError()) {
+      std::stringstream ss;
+      ss << "Body parsing error offset=" << doc.GetErrorOffset() << " error="
+         << RAPIDJSON_NAMESPACE::GetParseError_En(doc.GetParseError());
+      response.send(Pistache::Http::Code::Bad_Request, ss.str());
+      return;
+    }
+    response.send(Pistache::Http::Code::Ok, "Started");
+  } else {
+    std::stringstream ss;
+    ss << "Unrecognized resource [" << request.resource() << "]";
+    response.send(Pistache::Http::Code::Bad_Request, ss.str());
+  }
+}

--- a/src/oai_spgwu/rest_handler.h
+++ b/src/oai_spgwu/rest_handler.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2017 Sprint
+ *
+ * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The OpenAirInterface Software Alliance licenses this file to You under
+ * the terms found in the LICENSE file in the root of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef REST_HANDLER_H_
+#define REST_HANDLER_H_
+
+#include <iostream>
+#include <pistache/endpoint.h>
+#include <pistache/router.h>
+
+#include <memory>
+
+#define RAPIDJSON_NAMESPACE gwrapidjson
+#include "rapidjson/filereadstream.h"
+#include "rapidjson/document.h"
+
+extern RAPIDJSON_NAMESPACE::Document docSchema;
+
+class RestHandler : public Pistache::Http::Handler {
+ public:
+  HTTP_PROTOTYPE(RestHandler)
+  void onRequest(
+      const Pistache::Http::Request& request,
+      Pistache::Http::ResponseWriter response);
+};
+
+#endif /* REST_HANDLER_H_ */

--- a/src/spgwu/simpleswitch/pfcp_switch.cpp
+++ b/src/spgwu/simpleswitch/pfcp_switch.cpp
@@ -322,6 +322,17 @@ void pfcp_switch::setup_pdn_interfaces() {
           Logger::pfcp_switch().warn("%s returned %d", cmd.c_str(), rc);
         }
       }
+      if (spgwu_cfg.nsf.is_tcp_mss_clamping) {
+        cmd = fmt::format(
+            "iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN "
+            "-o {} -j TCPMSS --set-mss {} ",
+            spgwu_cfg.sgi.if_name.c_str(),
+            spgwu_cfg.nsf.tcp_mss);
+        rc = system((const char*) cmd.c_str());
+        if (rc) {
+          Logger::pfcp_switch().warn("%s returned %d", cmd.c_str(), rc);
+        }
+      }
     }
     if (it.prefix_ipv6) {
       std::string cmd = fmt::format(

--- a/src/spgwu/spgwu_config.cpp
+++ b/src/spgwu/spgwu_config.cpp
@@ -308,6 +308,13 @@ int spgwu_config::load(const string& config_file) {
   }
 
   try {
+    spgwu_cfg.lookupValue(SPGWU_CONFIG_STRING_REST_PORT, rest_port);
+  } catch (const SettingNotFoundException& nfex) {
+    Logger::spgwu_app().info(
+        "%s : %s, using defaults", nfex.what(), nfex.getPath());
+  }
+
+  try {
     spgwu_cfg.lookupValue(SPGWU_CONFIG_STRING_FQDN, fqdn);
     util::trim(fqdn);
   } catch (const SettingNotFoundException& nfex) {
@@ -654,6 +661,7 @@ void spgwu_config::display() {
   Logger::spgwu_app().info("Configuration:");
   Logger::spgwu_app().info("- FQDN ..................: %s", fqdn.c_str());
   Logger::spgwu_app().info("- Instance ..............: %d", instance);
+  Logger::spgwu_app().info("- REST port..............: %d", rest_port);
   Logger::spgwu_app().info("- PID dir ...............: %s", pid_dir.c_str());
   Logger::spgwu_app().info("- ITTI tasks:");
   Logger::spgwu_app().info("    ITTI Timer task:");

--- a/src/spgwu/spgwu_config.cpp
+++ b/src/spgwu/spgwu_config.cpp
@@ -380,6 +380,13 @@ int spgwu_config::load(const string& config_file) {
           nsf.bypass_ul_pfcp_rules = true;
         }
       }
+      nsf.is_tcp_mss_clamping = false;
+      if (nsf_cfg.lookupValue(SPGWU_CONFIG_STRING_TCP_MSS_CLAMPING, astring)) {
+        if (boost::iequals(astring, "yes")) {
+          nsf.is_tcp_mss_clamping = true;
+          nsf_cfg.lookupValue(SPGWU_CONFIG_STRING_TCP_MSS, nsf.tcp_mss);
+        }
+      }
     } catch (const SettingNotFoundException& nfex) {
       Logger::spgwu_app().info(
           "%s : %s, using defaults", nfex.what(), nfex.getPath());
@@ -776,6 +783,13 @@ void spgwu_config::display() {
       "    bypass_ul_pfcp_rules: %s",
       (nsf.bypass_ul_pfcp_rules) ? "yes" : "no");
 
+  Logger::spgwu_app().info(
+      "    tcp_mss_clamping: %s",
+      (nsf.is_tcp_mss_clamping) ? "yes" : "no");
+  if (nsf.is_tcp_mss_clamping) {
+    Logger::spgwu_app().info(
+        "    tcp_mss: %d", nsf.tcp_mss);
+  }
   Logger::spgwu_app().info("- SUPPORT_5G_FEATURES:");
   Logger::spgwu_app().info(
       "    enable_5g_features: %s",

--- a/src/spgwu/spgwu_config.hpp
+++ b/src/spgwu/spgwu_config.hpp
@@ -65,6 +65,8 @@ namespace spgwu {
 #define SPGWU_CONFIG_STRING_NETWORK_IPV6 "NETWORK_IPV6"
 #define SPGWU_CONFIG_STRING_ADDRESS_PREFIX_DELIMITER "/"
 #define SPGWU_CONFIG_STRING_SNAT "SNAT"
+#define SPGWU_CONFIG_STRING_TCP_MSS_CLAMPING "TCP_MSS_CLAMPING"
+#define SPGWU_CONFIG_STRING_TCP_MSS "TCP_MSS"
 #define SPGWU_CONFIG_STRING_MAX_PFCP_SESSIONS "MAX_PFCP_SESSIONS"
 #define SPGWU_CONFIG_STRING_SPGWC_LIST "SPGW-C_LIST"
 #define SPGWU_CONFIG_STRING_ITTI_TASKS "ITTI_TASKS"
@@ -126,6 +128,8 @@ typedef struct itti_cfg_s {
 // Non standart features
 typedef struct nsf_cfg_s {
   bool bypass_ul_pfcp_rules;
+  bool is_tcp_mss_clamping;
+  unsigned int  tcp_mss;
 } nsf_cfg_t;
 class spgwu_config {
  private:

--- a/src/spgwu/spgwu_config.hpp
+++ b/src/spgwu/spgwu_config.hpp
@@ -46,6 +46,7 @@ namespace spgwu {
 #define SPGWU_CONFIG_STRING_SPGWU_CONFIG "SPGW-U"
 #define SPGWU_CONFIG_STRING_PID_DIRECTORY "PID_DIRECTORY"
 #define SPGWU_CONFIG_STRING_INSTANCE "INSTANCE"
+#define SPGWU_CONFIG_STRING_REST_PORT "REST_PORT"
 #define SPGWU_CONFIG_STRING_FQDN "FQDN"
 #define SPGWU_CONFIG_STRING_INTERFACES "INTERFACES"
 #define SPGWU_CONFIG_STRING_INTERFACE_NAME "INTERFACE_NAME"
@@ -140,6 +141,7 @@ class spgwu_config {
   std::string pid_dir;
   unsigned int instance;
   std::string fqdn;
+  int rest_port;
   interface_cfg_t s1_up;
   interface_cfg_t sgi;
   interface_cfg_t sx;
@@ -172,6 +174,7 @@ class spgwu_config {
       : m_rw_lock(),
         pid_dir(),
         instance(0),
+		rest_port(9081),
         fqdn(),
         s1_up(),
         sgi(),


### PR DESCRIPTION
Fix libfolly issues, ubuntu 20.04 builds.
Enable TCP MSS clampling
Configuration file changed.
Default value for TCP MSS could be UE MTU minus 20 bytes (IPv4 header size)