### PR TITLE
Fix configurable number of DL threads for data path

### DIFF
--- a/src/spgwu/simpleswitch/pfcp_switch.hpp
+++ b/src/spgwu/simpleswitch/pfcp_switch.hpp
@@ -97,7 +97,7 @@ class pfcp_switch {
   // moodycamel::ConcurrentQueue<pfcp::pfcp_session*> create_session_q;
 
   void pdn_worker(const int id, const util::thread_sched_params& sched_params);
-  void pdn_read_loop(int sock_r, const util::thread_sched_params& sched_params);
+  void pdn_read_loop(int sock_r, util::thread_sched_params sched_params);
   int create_pdn_socket(
       const char* const ifname, const bool promisc, int& if_index);
   int create_pdn_socket(const char* const ifname);


### PR DESCRIPTION
Signed-off-by: lionelgo <29477918+lionelgo@users.noreply.github.com>
Despite spgwu configuration file was letting suppose the number of SGi processing threads was configurable, it was not.
Fixed in this PR.
Fixed the priority of producer thread be the priority of consumer thread minus 1 to test if out of sequence IP packets are still observed.