### PR TITLE
set GTPV1U socket option to REUSE_PORT

### DIFF
--- a/src/udp/udp.cpp
+++ b/src/udp/udp.cpp
@@ -135,6 +135,15 @@ int udp_server::create_socket(
     return errno;
   }
 
+  int on = 1;
+  if (setsockopt(sd, SOL_SOCKET, SO_REUSEPORT, &on, sizeof(on)) < 0) {
+    /*
+	 * Reuse port has failed...
+	 */
+	Logger::udp().error("Socket option reuse port failed (%s)\n", strerror(errno));
+	return errno;
+  }
+
   addr.sin_family      = AF_INET;
   addr.sin_port        = htons(port);
   addr.sin_addr.s_addr = address.s_addr;


### PR DESCRIPTION
To enable other sockets to bind on same port on the host, particularly for GTPV1-U port 2152
Signed-off-by: lionelgo <29477918+lionelgo@users.noreply.github.com>