### PR TITLE
fix(exit): catching SIGTERM

### DIFF
--- a/src/oai_spgwu/main.cpp
+++ b/src/oai_spgwu/main.cpp
@@ -122,11 +122,8 @@ int main(int argc, char** argv) {
 
   Logger::spgwu_app().startup("Options parsed");
 
-  struct sigaction sigIntHandler;
-  sigIntHandler.sa_handler = my_app_signal_handler;
-  sigemptyset(&sigIntHandler.sa_mask);
-  sigIntHandler.sa_flags = 0;
-  sigaction(SIGINT, &sigIntHandler, NULL);
+  std::signal(SIGTERM, my_app_signal_handler);
+  std::signal(SIGINT, my_app_signal_handler);
 
   // Config
   spgwu_cfg.load(Options::getlibconfigConfig());


### PR DESCRIPTION
catching `SIGTERM`
We also need to modify our tutorials w/:

```bash
docker-compose stop -t 2
docker logs ...
docker-compose down
```

So we can see in the logs the proper exit.
Related to this [issue](https://gitlab.eurecom.fr/oai/cn5g/oai-cn5g-fed/-/issues/4)