### PR TITLE
Expose user-plane address override

### DIFF
--- a/etc/spgw_u.conf
+++ b/etc/spgw_u.conf
@@ -63,7 +63,7 @@ SPGW-U =
             # STRING, interface name, YOUR NETWORK CONFIG HERE
             INTERFACE_NAME         = "{{ env["SGW_INTERFACE_NAME_FOR_S1U_S12_S4_UP"] if "SGW_INTERFACE_NAME_FOR_S1U_S12_S4_UP" in env.keys() else 'eth0' }}";
             # STRING, CIDR or "read to let app read interface configured IP address
-            IPV4_ADDRESS           = "read";
+            IPV4_ADDRESS           = "{{ env["SGW_ADDRESS_FOR_S1U_S12_S4_UP"] if "SGW_ADDRESS_FOR_S1U_S12_S4_UP" in env.keys() else 'read' }}";
             #PORT                   = 2152;                                     # Default is 2152
             SCHED_PARAMS :
             {


### PR DESCRIPTION
Offer a way to override, from the YAML, the user-plane address for S1U/N3 to be published to the RAN, to be able to handle NAT scenarii (e.g. for containers or VMs).