### PR TITLE
Decode fix for case no additional IEs in session related message

### DIFF
--- a/src/pfcp/3gpp_29.244.hpp
+++ b/src/pfcp/3gpp_29.244.hpp
@@ -511,7 +511,7 @@ class pfcp_msg : public pfcp_msg_header {
     // std::cout << std::dec<< " check_msg_length  = " << check_msg_length <<
     // std::endl;
     do {
-      ie = pfcp_ie::new_pfcp_ie_from_stream(is);
+      if (check_msg_length) ie = pfcp_ie::new_pfcp_ie_from_stream(is);
       if (ie) {
         ies_length += (pfcp_tlv::tlv_ie_length + ie->tlv.get_length());
         ies.push_back(std::shared_ptr<pfcp_ie>(ie));

--- a/src/pfcp/3gpp_29.244.hpp
+++ b/src/pfcp/3gpp_29.244.hpp
@@ -504,14 +504,14 @@ class pfcp_msg : public pfcp_msg_header {
   void load_from(std::istream& is) {
     pfcp_msg_header::load_from(is);
 
-    uint16_t check_msg_length = get_message_length() - 3 - 1;  // sn + spare
+    int16_t check_msg_length = get_message_length() - 3 - 1;  // sn + spare
     if (has_seid()) check_msg_length -= 8;
     pfcp_ie* ie         = nullptr;
     uint16_t ies_length = 0;
     // std::cout << std::dec<< " check_msg_length  = " << check_msg_length <<
     // std::endl;
     do {
-      if (check_msg_length) ie = pfcp_ie::new_pfcp_ie_from_stream(is);
+      if (check_msg_length > 0) ie = pfcp_ie::new_pfcp_ie_from_stream(is);
       if (ie) {
         ies_length += (pfcp_tlv::tlv_ie_length + ie->tlv.get_length());
         ies.push_back(std::shared_ptr<pfcp_ie>(ie));


### PR DESCRIPTION
Fix issue while decoding pfcp message with no additional IEs by checking length before.

e.g.
```bash
[2023-02-24T07:29:26.679896] [spgwu] [pfcp     ] [error] PFCP IE type 0 length 0
[2023-02-24T07:29:26.679919] [spgwu] [spgwu_app] [info ] Received SXAB_SESSION_DELETION_REQUEST seid 0x2 
```